### PR TITLE
fix ambiguous occurrence 'traverse', rm explict CC-delcont version

### DIFF
--- a/ZFS.cabal
+++ b/ZFS.cabal
@@ -23,7 +23,7 @@ description:         A implementation of a zipper filesystem using delimited con
 
 data-files:          zfs.pdf, README
 Cabal-Version:       >= 1.8
-Tested-With:         GHC==6.8.2
+Tested-With:         GHC==8.0.2
 build-type:          Simple
 
 source-repository head
@@ -36,7 +36,7 @@ Library
                            , unix
                            , network
                            , containers
-                           , CC-delcont <= 0.2
+                           , CC-delcont
         hs-source-dirs:      src
         exposed-modules:     ZFS, ZipperM
 

--- a/src/ZFS.hs
+++ b/src/ZFS.hs
@@ -14,7 +14,12 @@ Please see http://pobox.com/~oleg/ftp/papers/zfs-talk.pdf
 for the demo and explanations.
 
 -- $Id: ZFS.hs,v 1.8 2005/10/14 23:00:41 oleg Exp $
+
+NOTE: the above demo and explanation can be viewed at the following url:
+  - https://web.archive.org/web/20190809002903/http://okmij.org/ftp/continuations/ZFS/zfs-talk.pdf
 -}
+
+
 
 module ZFS where
 

--- a/src/ZipperM.hs
+++ b/src/ZipperM.hs
@@ -9,6 +9,7 @@ module ZipperM (Term(..)
                , promptP
               ) where
 
+import Prelude hiding (traverse)
 import Control.Monad.CC
 import Control.Monad.Identity
 import Control.Monad.Trans


### PR DESCRIPTION
This PR does the following:

- fixes a compilation/load error
- removes the explicit CC-delcont version (since I got a compilation error with the previous version)
- converts the pdf link in the source code comments to a wayback link

I can split this up into multiple PR's if needed/requested.

Note: `cabal` install still fails for me with warnings, but at least the code can be loaded in ghci

### before

```
$ ghci
GHCi, version 8.0.2: http://www.haskell.org/ghc/  :? for help
Prelude> :load src/ZFS.hs src/ZipperM.hs
[1 of 2] Compiling ZipperM          ( src/ZipperM.hs, interpreted )
[2 of 2] Compiling ZFS              ( src/ZFS.hs, interpreted )
...
src/ZipperM.hs:149:42: error:
    Ambiguous occurrence ‘traverse’
    It could refer to either ‘Prelude.traverse’,
                             imported from ‘Prelude’ at src/ZipperM.hs:2:8-14
                             (and originally defined in ‘Data.Traversable’)
                          or ‘ZipperM.traverse’, defined at src/ZipperM.hs:48:1
Failed, modules loaded: none.
```

### after

```
$ ghci
GHCi, version 8.0.2: http://www.haskell.org/ghc/  :? for help
Prelude> :load src/ZFS.hs src/ZipperM.hs
[1 of 2] Compiling ZipperM          ( src/ZipperM.hs, interpreted )
[2 of 2] Compiling ZFS              ( src/ZFS.hs, interpreted )
...
src/ZFS.hs:647:19: warning: [-Wdeprecations]
    In the use of ‘bitSize’
    (imported from Foreign, but defined in Data.Bits):
    Deprecated: "Use 'bitSizeMaybe' or 'finiteBitSize' instead"
Ok, modules loaded: ZFS, ZipperM.
```